### PR TITLE
Implement grayscale support

### DIFF
--- a/adafruit_uc8151d.py
+++ b/adafruit_uc8151d.py
@@ -38,9 +38,9 @@ _START_SEQUENCE = (
     b"\x50\x01\x97"  # CDI setting
 )
 
-_GRAYSCALE_START_SEQUENCE  = (
-    b"\x04\x80\xc8" # Power on
-    b"\x00\x01\xbf" # Panel setting
+_GRAYSCALE_START_SEQUENCE = (
+    b"\x04\x80\xc8"  # Power on
+    b"\x00\x01\xbf"  # Panel setting
     b"\x50\x01\x97"  # CDI setting
     # Common voltage
     b"\x20\x2a"

--- a/adafruit_uc8151d.py
+++ b/adafruit_uc8151d.py
@@ -108,7 +108,6 @@ class UC8151D(displayio.EPaperDisplay):
 
     def __init__(self, bus, **kwargs):
         if kwargs.get("grayscale", False):
-            print("grayscale is true")
             start_sequence = bytearray(_GRAYSCALE_START_SEQUENCE)
         else:
             start_sequence = bytearray(_START_SEQUENCE)

--- a/adafruit_uc8151d.py
+++ b/adafruit_uc8151d.py
@@ -94,9 +94,11 @@ _STOP_SEQUENCE = b"\x50\x01\xf7" b"\x07\x01\xA5"  # CDI setting  # Deep Sleep
 # pylint: disable=too-few-public-methods
 class UC8151D(displayio.EPaperDisplay):
     r"""UC8151D driver
+
     :param bus: The data bus the display is on
     :param \**kwargs:
         See below
+
     :Keyword Arguments:
         * *width* (``int``) --
           Display width

--- a/adafruit_uc8151d.py
+++ b/adafruit_uc8151d.py
@@ -38,15 +38,65 @@ _START_SEQUENCE = (
     b"\x50\x01\x97"  # CDI setting
 )
 
+_GRAYSCALE_START_SEQUENCE  = (
+    b"\x04\x80\xc8" # Power on
+    b"\x00\x01\xbf" # Panel setting
+    b"\x50\x01\x97"  # CDI setting
+    # Common voltage
+    b"\x20\x2a"
+    b"\x00\x0A\x00\x00\x00\x01"
+    b"\x60\x14\x14\x00\x00\x01"
+    b"\x00\x14\x00\x00\x00\x01"
+    b"\x00\x13\x0A\x01\x00\x01"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    # White to White
+    b"\x21\x2a"
+    b"\x40\x0A\x00\x00\x00\x01"
+    b"\x90\x14\x14\x00\x00\x01"
+    b"\x10\x14\x0A\x00\x00\x01"
+    b"\xA0\x13\x01\x00\x00\x01"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    # Black to White
+    b"\x22\x2a"
+    b"\x40\x0A\x00\x00\x00\x01"
+    b"\x90\x14\x14\x00\x00\x01"
+    b"\x00\x14\x0A\x00\x00\x01"
+    b"\x99\x0B\x04\x04\x01\x01"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    # White to Black
+    b"\x23\x2a"
+    b"\x40\x0A\x00\x00\x00\x01"
+    b"\x90\x14\x14\x00\x00\x01"
+    b"\x00\x14\x0A\x00\x00\x01"
+    b"\x99\x0C\x01\x03\x04\x01"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    # Black to Black
+    b"\x24\x2a"
+    b"\x80\x0A\x00\x00\x00\x01"
+    b"\x90\x14\x14\x00\x00\x01"
+    b"\x20\x14\x0A\x00\x00\x01"
+    b"\x50\x13\x01\x00\x00\x01"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00"
+)
+
+
 _STOP_SEQUENCE = b"\x50\x01\xf7" b"\x07\x01\xA5"  # CDI setting  # Deep Sleep
 # pylint: disable=too-few-public-methods
 class UC8151D(displayio.EPaperDisplay):
     r"""UC8151D driver
-
     :param bus: The data bus the display is on
     :param \**kwargs:
         See below
-
     :Keyword Arguments:
         * *width* (``int``) --
           Display width
@@ -57,6 +107,11 @@ class UC8151D(displayio.EPaperDisplay):
     """
 
     def __init__(self, bus, **kwargs):
+        if kwargs.get("grayscale", False):
+            print("grayscale is true")
+            start_sequence = bytearray(_GRAYSCALE_START_SEQUENCE)
+        else:
+            start_sequence = bytearray(_START_SEQUENCE)
         width = kwargs["width"]
         height = kwargs["height"]
         if "rotation" in kwargs and kwargs["rotation"] % 180 != 0:
@@ -64,7 +119,7 @@ class UC8151D(displayio.EPaperDisplay):
 
         super().__init__(
             bus,
-            _START_SEQUENCE,
+            start_sequence,
             _STOP_SEQUENCE,
             **kwargs,
             ram_width=128,

--- a/examples/uc8151d_grayscale_test.py
+++ b/examples/uc8151d_grayscale_test.py
@@ -1,3 +1,14 @@
+# SPDX-FileCopyrightText: 2022 Martin Refseth, written for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+"""Simple test script for 1.54" 152x152 grayscale display.
+
+Supported products:
+  * 1.54" Grayscale Display (GDEW0154T8D)
+  """
+# pylint: disable=no-member
+
 import time
 import board
 import displayio
@@ -6,6 +17,7 @@ import adafruit_uc8151d
 
 displayio.release_displays()
 
+# Pinout intended for use with a Raspberry Pi Pico
 clk = board.GP10
 si = board.GP11
 dc = board.GP8
@@ -27,27 +39,27 @@ display = adafruit_uc8151d.UC8151D(
 bitmap = displayio.Bitmap(152, 152, 4)
 
 # Draw Black
-for x in range(0,152):
-    for y in range(0,38):
+for x in range(0, 152):
+    for y in range(0, 38):
         bitmap[x, y] = 0
-#Draw Dark Gray
-for x in range(0,152):
-    for y in range(38,76):
+# Draw Dark Gray
+for x in range(0, 152):
+    for y in range(38, 76):
         bitmap[x, y] = 1
-#Draw Light Gray
-for x in range(0,152):
-    for y in range(76,114):
+# Draw Light Gray
+for x in range(0, 152):
+    for y in range(76, 114):
         bitmap[x, y] = 2
-#Draw White
-for x in range(0,152):
-    for y in range(114,152):
+# Draw White
+for x in range(0, 152):
+    for y in range(114, 152):
         bitmap[x, y] = 3
 
 palette = displayio.Palette(4)
-palette[0] = 0x000000 # Black
-palette[1] = 0x404040 # Dark Gray
-palette[2] = 0x808080 # Light Gray
-palette[3] = 0xFFFFFF # White
+palette[0] = 0x000000  # Black
+palette[1] = 0x404040  # Dark Gray
+palette[2] = 0x808080  # Light Gray
+palette[3] = 0xFFFFFF  # White
 
 g = displayio.Group()
 t = displayio.TileGrid(bitmap, pixel_shader=palette)

--- a/examples/uc8151d_grayscale_test.py
+++ b/examples/uc8151d_grayscale_test.py
@@ -1,0 +1,56 @@
+import time
+import board
+import displayio
+import busio
+import adafruit_uc8151d
+
+displayio.release_displays()
+
+clk = board.GP10
+si = board.GP11
+dc = board.GP8
+cs = board.GP9
+rst = board.GP12
+busy = board.GP13
+
+display_bus = displayio.FourWire(
+    busio.SPI(clk, si), command=dc, chip_select=cs, reset=rst, baudrate=1000000
+)
+
+time.sleep(1)
+
+display = adafruit_uc8151d.UC8151D(
+    display_bus, width=152, height=152, busy_pin=busy, rotation=180, grayscale=True
+)
+
+
+bitmap = displayio.Bitmap(152, 152, 4)
+
+# Draw Black
+for x in range(0,152):
+    for y in range(0,38):
+        bitmap[x, y] = 0
+#Draw Dark Gray
+for x in range(0,152):
+    for y in range(38,76):
+        bitmap[x, y] = 1
+#Draw Light Gray
+for x in range(0,152):
+    for y in range(76,114):
+        bitmap[x, y] = 2
+#Draw White
+for x in range(0,152):
+    for y in range(114,152):
+        bitmap[x, y] = 3
+
+palette = displayio.Palette(4)
+palette[0] = 0x000000 # Black
+palette[1] = 0x404040 # Dark Gray
+palette[2] = 0x808080 # Light Gray
+palette[3] = 0xFFFFFF # White
+
+g = displayio.Group()
+t = displayio.TileGrid(bitmap, pixel_shader=palette)
+g.append(t)
+display.show(g)
+display.refresh()


### PR DESCRIPTION
Adds grayscale support for displays like GDEW0154T8D, based on https://github.com/adafruit/Adafruit_CircuitPython_IL0373/blob/main/adafruit_il0373.py


![image](https://user-images.githubusercontent.com/20230450/169390282-9cffa097-8a74-4916-a9c6-a49b719c361a.png)


Test image used (github doesn't allow .bmp):
![Grayscale](https://user-images.githubusercontent.com/20230450/169588883-43d9fe62-c82f-429c-b4a5-2c9432e3f3a5.png)

