### PR TITLE
fix circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install uc8151d
+    circup install adafruit_uc8151d
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Resolves the following issue for this library: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407 for this library

Editted by: tekktrik (removing auto-linking issue)